### PR TITLE
Update direct cache archive URL handling.

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -61,14 +61,14 @@ workflows:
             echo '{ "stack_id": "Wrong Stack ID" }' > "/tmp/archive_info.json"
             tar -cvf "archive.tar.gz" "/tmp/archive_info.json" "File.txt"
             rm -rf "$TMP_DIR/File.txt"
-            envman add --key "BITRISE_CACHE_API_URL" --value "file://$TMP_DIR/archive.tar.gz"
+            envman add --key "CACHE_ARCHIVE_URL" --value "file://$TMP_DIR/archive.tar.gz"
     - path::./:
         title: Step Test
         run_if: true
         is_skippable: false
         inputs:
-        - is_debug_mode: true 
-        - cache_api_url: $BITRISE_CACHE_API_URL
+        - is_debug_mode: true
+        - cache_api_url: $CACHE_ARCHIVE_URL
         - allow_fallback: "false"
     - script:
         title: Test if archive uncompressed
@@ -110,14 +110,14 @@ workflows:
             echo { \"stack_id\": \"${BITRISEIO_STACK_ID}\" } > $TMP_DIR/archive_info.json
             tar -cvf "archive.tar.gz" "archive_info.json" "File.txt"
             rm -rf "$TMP_DIR/File.txt"
-            envman add --key "BITRISE_CACHE_API_URL" --value "file://$TMP_DIR/archive.tar.gz"
+            envman add --key "CACHE_ARCHIVE_URL" --value "file://$TMP_DIR/archive.tar.gz"
     - path::./:
         title: Step Test
         run_if: true
         is_skippable: false
         inputs:
-        - is_debug_mode: true 
-        - cache_api_url: $BITRISE_CACHE_API_URL
+        - is_debug_mode: true
+        - cache_api_url: $CACHE_ARCHIVE_URL
         - allow_fallback: "false"
     - script:
         title: Test if archive uncompressed
@@ -159,14 +159,14 @@ workflows:
             echo { \"stack_id\": \"${BITRISEIO_STACK_ID}\" } > $TMP_DIR/archive_info.json
             tar -cvf "archive.tar" "archive_info.json" "File.txt"
             rm -rf "$TMP_DIR/File.txt"
-            envman add --key "BITRISE_CACHE_API_URL" --value "file://$TMP_DIR/archive.tar"
+            envman add --key "CACHE_ARCHIVE_URL" --value "file://$TMP_DIR/archive.tar"
     - path::./:
         title: Step Test
         run_if: true
         is_skippable: false
         inputs:
         - is_debug_mode: true
-        - cache_api_url: $BITRISE_CACHE_API_URL
+        - cache_api_url: $CACHE_ARCHIVE_URL
         - allow_fallback: "false"
     - script:
         title: Test if archive uncompressed
@@ -260,19 +260,18 @@ workflows:
                 shopt -s nocasematch
                 if [[ `uname -s` == "linux" ]]
                 then
-                  ARCHIVE_URL="https://storage.googleapis.com/cache_pull_test_bucket/linux-comp.tar.gz"
+                  CACHE_ARCHIVE_URL="https://storage.googleapis.com/cache_pull_test_bucket/linux-comp.tar.gz"
                 else
-                  ARCHIVE_URL="https://storage.googleapis.com/cache_pull_test_bucket/macos-comp.tar.gz"
+                  CACHE_ARCHIVE_URL="https://storage.googleapis.com/cache_pull_test_bucket/macos-comp.tar.gz"
                 fi
-                envman add --key "BITRISE_CACHE_API_URL" --value $ARCHIVE_URL
+                envman add --key "CACHE_ARCHIVE_URL" --value $CACHE_ARCHIVE_URL
       - path::./:
           title: Step Test
           run_if: true
           is_skippable: false
           inputs:
             - is_debug_mode: true
-            - cache_api_url: $BITRISE_CACHE_API_URL
-            - is_direct_url: true
+            - cache_api_url: $CACHE_ARCHIVE_URL
             - extract_to_relative_path: true
             - allow_fallback: "false"
       - script:
@@ -313,19 +312,18 @@ workflows:
                 shopt -s nocasematch
                 if [[ `uname -s` == "linux" ]]
                 then
-                  ARCHIVE_URL="https://storage.googleapis.com/cache_pull_test_bucket/linux.tar.gz"
+                  CACHE_ARCHIVE_URL="https://storage.googleapis.com/cache_pull_test_bucket/linux.tar.gz"
                 else
-                  ARCHIVE_URL="https://storage.googleapis.com/cache_pull_test_bucket/macos.tar.gz"
+                  CACHE_ARCHIVE_URL="https://storage.googleapis.com/cache_pull_test_bucket/macos.tar.gz"
                 fi
-                envman add --key "BITRISE_CACHE_API_URL" --value $ARCHIVE_URL
+                envman add --key "CACHE_ARCHIVE_URL" --value $CACHE_ARCHIVE_URL
       - path::./:
           title: Step Test
           run_if: true
           is_skippable: false
           inputs:
             - is_debug_mode: true
-            - cache_api_url: $BITRISE_CACHE_API_URL
-            - is_direct_url: true
+            - cache_api_url: $CACHE_ARCHIVE_URL
             - extract_to_relative_path: true
             - allow_fallback: "false"
       - script:

--- a/main.go
+++ b/main.go
@@ -25,7 +25,6 @@ type Config struct {
 	CacheAPIURL           string `env:"cache_api_url"`
 	DebugMode             bool   `env:"is_debug_mode,opt[true,false]"`
 	AllowFallback         bool   `env:"allow_fallback,opt[true,false]"`
-	IsDirectURL           bool   `env:"is_direct_url,opt[true,false]"`
 	ExtractToRelativePath bool   `env:"extract_to_relative_path,opt[true,false]"`
 
 	StackID   string `env:"BITRISEIO_STACK_ID"`
@@ -165,6 +164,10 @@ func failf(format string, args ...interface{}) {
 	os.Exit(1)
 }
 
+func isBitriseCacheAPIURL(url string) bool {
+	return url == os.Getenv("BITRISE_CACHE_API_URL")
+}
+
 func main() {
 	var conf Config
 	if err := stepconf.Parse(&conf); err != nil {
@@ -201,7 +204,7 @@ func main() {
 		log.Infof("Downloading remote cache archive")
 
 		var err error
-		if !conf.IsDirectURL {
+		if isBitriseCacheAPIURL(conf.CacheAPIURL) {
 			cacheURI, err = getCacheDownloadURL(conf.CacheAPIURL)
 			if err != nil {
 				failf("Failed to get cache download url: %s", err)

--- a/step.yml
+++ b/step.yml
@@ -78,16 +78,6 @@ inputs:
       value_options:
       - "true"
       - "false"
-  - is_direct_url: "false"
-    opts:
-      category: Debug
-      title: Sidestep Cache API?
-      description: Is the provided URL direct download address?
-      is_required: true
-      is_dont_change_value: true
-      value_options:
-      - "true"
-      - "false"
   - extract_to_relative_path: "false"
     opts:
       category: Debug


### PR DESCRIPTION
Remove `is_direct_url` input, handle in code if `cache_api_url` is not the default Bitrise Cache API URL (`BITRISE_CACHE_API_URL `)