### PR TITLE
Add extra rules to match GEN2 machines together and to GEN1 with different ids

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -268,7 +269,7 @@ func main() {
 			}
 			log.Printf("archive stack id: %s", archiveStackID)
 
-			if archiveStackID != currentStackID {
+			if !isSameStack(archiveStackID, currentStackID) {
 				log.Warnf("Cache was created on stack: %s, current stack: %s", archiveStackID, currentStackID)
 				log.Warnf("Skipping cache pull, because of the stack has changed")
 
@@ -323,4 +324,13 @@ func main() {
 	fmt.Println()
 	log.Donef("Done")
 	log.Printf("Took: " + time.Since(startTime).String())
+}
+
+func isSameStack(archiveStackID string, currentStackID string) bool {
+	// TODO This check is a temporary solution to support GEN2 VMs having different ids for same stack types
+	if r, err := regexp.Compile("^(.+)-gen2.*$"); err == nil {
+		currentStackID = r.ReplaceAllString(currentStackID, "$1")
+		archiveStackID = r.ReplaceAllString(archiveStackID, "$1")
+	}
+	return archiveStackID == currentStackID
 }

--- a/main.go
+++ b/main.go
@@ -328,9 +328,8 @@ func main() {
 
 func isSameStack(archiveStackID string, currentStackID string) bool {
 	// TODO This check is a temporary solution to support GEN2 VMs having different ids for same stack types
-	if r, err := regexp.Compile("^(.+)-gen2.*$"); err == nil {
-		currentStackID = r.ReplaceAllString(currentStackID, "$1")
-		archiveStackID = r.ReplaceAllString(archiveStackID, "$1")
-	}
+	r := regexp.MustCompile("^(.+)-gen2.*$")
+	currentStackID = r.ReplaceAllString(currentStackID, "$1")
+	archiveStackID = r.ReplaceAllString(archiveStackID, "$1")
 	return archiveStackID == currentStackID
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,93 @@
+package main
+
+import "testing"
+
+func Test_isSameStack(t *testing.T) {
+	type args struct {
+		archiveStackID string
+		currentStackID string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			"Going from Gen2 to Gen1",
+			args{archiveStackID: "osx-xcode-12.3.x-gen2-mmg4-12c-60gb-300gb-atl01-ded001", currentStackID: "osx-xcode-12.3.x"},
+			true,
+		},
+		{
+			"Going from Gen2 to Gen2 same machine",
+			args{archiveStackID: "osx-xcode-12.3.x-gen2-mmg4-12c-60gb-300gb-atl01-ded001", currentStackID: "osx-xcode-12.3.x-gen2-mmg4-12c-60gb-300gb-atl01-ded001"},
+			true,
+		},
+		{
+			"Going from Gen2 to Gen2 different stack",
+			args{archiveStackID: "osx-xcode-12.3.x-gen2-mmg4-12c-60gb-300gb-atl01-ded001", currentStackID: "osx-xcode-12.4.x-gen2-mmg4-12c-60gb-300gb-atl01-ded001"},
+			false,
+		},
+		{
+			"Going from Gen2 to Gen2 different machine",
+			args{archiveStackID: "osx-xcode-12.3.x-gen2-mmg4-4c-20gb-300gb-atl01-ded001", currentStackID: "osx-xcode-12.3.x-gen2-mmg4-12c-60gb-300gb-atl01-ded001"},
+			true,
+		},
+		{
+			"Going from Gen1 to Gen2",
+			args{archiveStackID: "osx-xcode-12.3.x", currentStackID: "osx-xcode-12.3.x-gen2-mmg4-12c-60gb-300gb-atl01-ded001"},
+			true,
+		},
+		{
+			"Going from Gen1 to Gen2 different stack",
+			args{archiveStackID: "osx-xcode-12.4.x", currentStackID: "osx-xcode-12.3.x-gen2-mmg4-12c-60gb-300gb-atl01-ded001"},
+			false,
+		},
+		{
+			"Going from Gen2 to Gen1 different stack",
+			args{archiveStackID: "osx-xcode-12.4.x-gen2-mmg4-12c-60gb-300gb-atl01-ded001", currentStackID: "osx-xcode-12.3.x"},
+			false,
+		},
+		{
+			"Going from Ubuntu to iOS",
+			args{archiveStackID: "linux-docker-android", currentStackID: "osx-xcode-12.3.x"},
+			false,
+		},
+		{
+			"Going from Ubuntu to Ubuntu",
+			args{archiveStackID: "linux-docker-android", currentStackID: "linux-docker-android"},
+			true,
+		},
+		{
+			"Going from iOS to Ubuntu",
+			args{archiveStackID: "osx-xcode-12.3.x", currentStackID: "linux-docker-android"},
+			false,
+		},
+		{
+			"Going from iOS to iOS",
+			args{archiveStackID: "osx-xcode-12.3.x", currentStackID: "osx-xcode-12.3.x"},
+			true,
+		},
+		{
+			"Going from Ubuntu to Ubuntu LTS",
+			args{archiveStackID: "linux-docker-android", currentStackID: "linux-docker-android-lts"},
+			false,
+		},
+		{
+			"Going from Ubuntu LTS to Ubuntu",
+			args{archiveStackID: "linux-docker-android-lts", currentStackID: "linux-docker-android"},
+			false,
+		},
+		{
+			"Going from Ubuntu to Gen2 iOS",
+			args{archiveStackID: "linux-docker-android", currentStackID: "osx-xcode-12.3.x-gen2-mmg4-12c-60gb-300gb-atl01-ded001"},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isSameStack(tt.args.archiveStackID, tt.args.currentStackID); got != tt.want {
+				t.Errorf("isSameStack() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -13,6 +13,16 @@ func Test_isSameStack(t *testing.T) {
 		want bool
 	}{
 		{
+			"Going from empty to iOS",
+			args{archiveStackID: "", currentStackID: "osx-xcode-12.3.x"},
+			false,
+		},
+		{
+			"Going from iOS to empty",
+			args{archiveStackID: "osx-xcode-12.3.x", currentStackID: ""},
+			false,
+		},
+		{
 			"Going from Gen2 to Gen1",
 			args{archiveStackID: "osx-xcode-12.3.x-gen2-mmg4-12c-60gb-300gb-atl01-ded001", currentStackID: "osx-xcode-12.3.x"},
 			true,

--- a/main_test.go
+++ b/main_test.go
@@ -63,9 +63,14 @@ func Test_isSameStack(t *testing.T) {
 			false,
 		},
 		{
-			"Going from iOS to iOS",
+			"Going from iOS to iOS same stack",
 			args{archiveStackID: "osx-xcode-12.3.x", currentStackID: "osx-xcode-12.3.x"},
 			true,
+		},
+		{
+			"Going from iOS to iOS different stack",
+			args{archiveStackID: "osx-xcode-12.3.x", currentStackID: "osx-xcode-12.4.x"},
+			false,
 		},
 		{
 			"Going from Ubuntu to Ubuntu LTS",


### PR DESCRIPTION
### Checklist

- [✅ ] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _MINOR_ [version update](https://semver.org/)

### Context

GEN2 machines have a temporary state where their ids are different for the
same kinds of stacks so we have to apply special logic to match them together
and the related GEN1 stack

[STEP-448]

### Changes

- Made stack comparison be aware of GEN2 naming scheme and applied changes accordingly
- Added test cases to cover most possibilities

### Investigation details

We understand that the current solution is not ideal but has been implemented this way so the Build team is not blocked. We consider this change a temporary solution.


[STEP-448]: https://bitrise.atlassian.net/browse/STEP-448