### PR TITLE
Add a parameter to ignore stack difference

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -26,6 +26,7 @@ workflows:
     - local_tar_test
     - local_gzip_test
     - local_stack_change_test
+    - local_stack_change_test_ignore_change
 
   go-tests:
     steps:
@@ -82,6 +83,58 @@ workflows:
 
             if [ -f $TMP_DIR/File.txt ]; then
               echo "File.txt should not exist"
+              exit 1
+            fi
+
+  local_stack_change_test_ignore_change:
+    envs:
+    - TMP_DIR: $ORIG_BITRISE_SOURCE_DIR/_tmp_local_stack_change_test_ignore_change
+    before_run:
+    - _set_valid_stackid
+    steps:
+    - script:
+        title: Cleanup $TMP_DIR
+        inputs:
+        - content: |
+            #!/bin/bash
+            set -ex
+            rm -rf "$TMP_DIR"
+    - change-workdir:
+        title: Switch working dir to $TMP_DIR
+        run_if: true
+        inputs:
+        - path: $TMP_DIR
+        - is_create_path: true
+    - script:
+        title: Create test archive
+        inputs:
+        - content: |
+            #!/bin/bash
+            set -ex
+
+            echo "test" > "$TMP_DIR/File.txt"
+            echo '{ "stack_id": "nonmatching-id", "architecture": "nonmatching-arch" }' > "/tmp/archive_info.json"
+            tar -cvf "archive.tar.gz" "/tmp/archive_info.json" "File.txt"
+            rm -rf "$TMP_DIR/File.txt"
+            envman add --key "CACHE_ARCHIVE_URL" --value "file://$TMP_DIR/archive.tar.gz"
+    - path::./:
+        title: Step Test
+        run_if: true
+        is_skippable: false
+        inputs:
+        - is_debug_mode: true
+        - cache_api_url: $CACHE_ARCHIVE_URL
+        - allow_fallback: "false"
+        - ignore_stack_difference: "true"
+    - script:
+        title: Test if archive uncompressed
+        inputs:
+        - content: |
+            # !/bin/env bash
+            set -ex
+
+            if [ ! -f $TMP_DIR/File.txt ]; then
+              echo "File.txt should exist"
               exit 1
             fi
 

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ type Config struct {
 	DebugMode             bool   `env:"is_debug_mode,opt[true,false]"`
 	AllowFallback         bool   `env:"allow_fallback,opt[true,false]"`
 	ExtractToRelativePath bool   `env:"extract_to_relative_path,opt[true,false]"`
+	IgnoreStackDifference bool   `env:"ignore_stack_difference,opt[true,false]"`
 
 	StackID   string `env:"BITRISEIO_STACK_ID"`
 	BuildSlug string `env:"BITRISE_BUILD_SLUG"`
@@ -123,7 +124,7 @@ func main() {
 			}
 			log.Printf("archive stack: %s", archiveStackInfo)
 
-			if !isSameStack(archiveStackInfo, currentStackInfo) {
+			if !conf.IgnoreStackDifference && !isSameStack(archiveStackInfo, currentStackInfo) {
 				log.Warnf("Cache was created on stack: %s, current stack: %s", archiveStackInfo, currentStackInfo)
 				log.Warnf("Skipping cache pull, as the stack has changed")
 

--- a/step.yml
+++ b/step.yml
@@ -95,3 +95,11 @@ inputs:
       value_options:
       - "true"
       - "false"
+  - ignore_stack_difference: "false"
+    opts:
+      title: "Ignore stack difference"
+      summary: "Allow to use the same cache across different Bitrise stacks"
+      is_required: false
+      value_options:
+      - "true"
+      - "false"

--- a/step.yml
+++ b/step.yml
@@ -98,7 +98,7 @@ inputs:
   - ignore_stack_difference: "false"
     opts:
       title: "Ignore stack difference"
-      summary: "Allow to use the same cache across different Bitrise stacks"
+      summary: "Allow to use the same cache across different Bitrise stacks. Use at your own risk, it might cause build problems."
       is_required: false
       value_options:
       - "true"


### PR DESCRIPTION
### Checklist
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
Requires a *MINOR* [version update](https://semver.org/)

### Context

In Reddit's use case, only non-binary content is cached in Bitrise caches. This PR allows us to share the cache across the stacks in the same branch.

### Changes

Added a `ignore_stack_difference` parameter to the step configuration and used it to opt out of version checks if enabled.

### Investigation details

The only alternative is to use previous versions of the step or to not use caches for some machines building on the same branch.

### Decisions

We are willing to take the risk of sharing caches across differing stacks, as our caches are not platform-specific.