### PR TITLE
Handle empty cache response better

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -268,11 +268,11 @@ workflows:
             # !/bin/env bash
             set -ex
             echo "test" > $TMP_DIR/File.txt
-#    - cache-push:
-#        run_if: true
-#        inputs:
-#        - cache_paths: $TMP_DIR/File.txt
-#        - cache_api_url: $BITRISE_CACHE_API_URL
+    - cache-push:
+        run_if: true
+        inputs:
+        - cache_paths: $TMP_DIR/File.txt
+        - cache_api_url: $BITRISE_CACHE_API_URL
     - script:
         title: Remove test File
         inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -268,11 +268,11 @@ workflows:
             # !/bin/env bash
             set -ex
             echo "test" > $TMP_DIR/File.txt
-    - cache-push:
-        run_if: true
-        inputs:
-        - cache_paths: $TMP_DIR/File.txt
-        - cache_api_url: $BITRISE_CACHE_API_URL
+#    - cache-push:
+#        run_if: true
+#        inputs:
+#        - cache_paths: $TMP_DIR/File.txt
+#        - cache_api_url: $BITRISE_CACHE_API_URL
     - script:
         title: Remove test File
         inputs:

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -83,7 +84,11 @@ func main() {
 		if isBitriseCacheAPIURL(conf.CacheAPIURL) {
 			cacheURI, err = getCacheDownloadURL(conf.CacheAPIURL)
 			if err != nil {
-				failf("Failed to get cache download url: %s", err)
+				if errors.Is(err, errNoCache) {
+					log.Donef("No saved cache found")
+					os.Exit(0)
+				}
+				failf("Failed to get cache download URL: %s", err)
 			}
 		} else {
 			cacheURI = conf.CacheAPIURL

--- a/network.go
+++ b/network.go
@@ -16,6 +16,7 @@ import (
 )
 
 var client = retry.NewHTTPClient()
+var errNoCache = errors.New("no cache entry found")
 
 // downloadCacheArchive downloads the cache archive and returns the downloaded file's path.
 // If the URI points to a local file it returns the local paths.
@@ -91,9 +92,12 @@ func getCacheDownloadURL(cacheAPIURL string) (string, error) {
 		return "", fmt.Errorf("request sent, but failed to read response body (http-code: %d): %s", resp.StatusCode, body)
 	}
 
+	if resp.StatusCode == http.StatusNotFound {
+		return "", errNoCache
+	}
+
 	if resp.StatusCode < 200 || resp.StatusCode > 202 {
-		log.Debugf("HTTP %d: %s", resp.StatusCode, body)
-		return "", fmt.Errorf("build cache not found: probably cache not initialised yet (first cache push initialises the cache), nothing to worry about ;)")
+		return "", fmt.Errorf("HTTP %d: %s", resp.StatusCode, body)
 	}
 
 	var respModel struct {

--- a/network.go
+++ b/network.go
@@ -92,6 +92,7 @@ func getCacheDownloadURL(cacheAPIURL string) (string, error) {
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode > 202 {
+		log.Debugf("HTTP %d: %s", resp.StatusCode, body)
 		return "", fmt.Errorf("build cache not found: probably cache not initialised yet (first cache push initialises the cache), nothing to worry about ;)")
 	}
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

During the first build of a new project, this step is marked as failed because there is no cache archive yet to restore. The step is marked as skippable, so it won't mark the entire build as failed, but it's still a confusing error message in the logs.

### Changes

Don't mark the "no cache found" scenario as an error, just exit the step early with a successful exit code.

<img width="346" alt="image" src="https://user-images.githubusercontent.com/1694986/188872890-0e1ba000-a697-4c44-8bb3-46a601518dca.png">


### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
